### PR TITLE
Added date/time/status display

### DIFF
--- a/BetterLaundryMonitor_Child.groovy
+++ b/BetterLaundryMonitor_Child.groovy
@@ -17,7 +17,7 @@
  *  for the specific language governing permissions and limitations under the License.
  *
  */
-	public static String version()      {  return "v1.4.4"  }
+	public static String version()      {  return "v1.4.5"  }
 
 
 import groovy.time.*


### PR DESCRIPTION
Displays start/finished status with english-language relative date appended to the app.label, e.g.: "(finished yesterday at 9:39pm)"

Also, reduced "extraneous" watt value to 1500 watts - the maximum we should see on a 15amp circuit (zooz power switches will occaisionally glitch to 8000-20000, setting off a phantom cycle start/end. This value should probably be configurable, to tolerate different power switch idiosyncracies).