### PR TITLE
Fix bug with power updates more frequent than delayEndDelay

### DIFF
--- a/BetterLaundryMonitor_Child.groovy
+++ b/BetterLaundryMonitor_Child.groovy
@@ -209,8 +209,10 @@ def powerHandler(evt) {
 		atomicState.powerOffDelay = 0;
 	    
 	}
-	// If the Machine stops drawing power for X times in a row, the cycle is complete, send notification.
-	else if (atomicState.cycleOn && latestPower < endThreshold) {
+	// If the Machine stops drawing power for X times in a row, the cycle is complete, send notification
+	// or schedule future check if cycleEnd isn't set already
+	else if (atomicState.cycleOn && (latestPower < endThreshold) && (atomicState.cycleEnding != true)) {
+		// cycleDone already scheduled if cycleEnd is set already
 		atomicState.cycleEnding = true
 		atomicState.cycleEnd = now()
 		if (delayEndDelay > 0) {


### PR DESCRIPTION
If powerHandler was called more frequently than delayEndDelay
minutes (if it is a valid value), with a value less than delayEndPwr,
cycleDone() would continually be pushed out by each update until
powerHandler was called more than delayEndDelay minutes from its
previous call.

Fix this issue by checking if atomicState.cycleEnding is true before
scheduling cycleDone(). This will allow subsequent calls to stop
rescheduling the call to cycleDone() such that it will be called
delayEndDelay * 60 seconds after it was first scheduled. Subsequent
reports of power will be ignore unless they go above the startThreshold
again (and cycleEnding will be set false).